### PR TITLE
General numeric type support

### DIFF
--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -273,6 +273,11 @@ function parse_command_line(args)
         arg_type = RecoStrategy.Strategy
         default = RecoStrategy.Best
 
+        "--type", "-T"
+        help = """Numerical type to use for the reconstruction (Float32, Float64)"""
+        arg_type = Symbol
+        default = :Float64
+
         "--nsamples", "-m"
         help = "Number of measurement points to acquire."
         arg_type = Int
@@ -331,9 +336,9 @@ function main()
 
     # Try to read events into the correct type!
     if JetReconstruction.is_ee(args[:algorithm])
-        jet_type = EEjet
+        jet_type = EEjet{eval(args[:type])}
     else
-        jet_type = PseudoJet
+        jet_type = PseudoJet{eval(args[:type])}
     end
     events::Vector{Vector{jet_type}} = read_final_state_particles(args[:file],
                                                                   maxevents = args[:maxevents],

--- a/examples/jetreco.jl
+++ b/examples/jetreco.jl
@@ -140,17 +140,19 @@ function main()
     logger = ConsoleLogger(stdout, Logging.Info)
     global_logger(logger)
     # Try to read events into the correct type!
-    if JetReconstruction.is_ee(args[:algorithm])
-        jet_type = EEjet
+    # If we don't have an algorithm we default to PseudoJet
+    if !isnothing(args[:algorithm])
+        JetReconstruction.is_ee(args[:algorithm])
+        jet_type = EEjet{Float64}
     else
-        jet_type = PseudoJet
+        jet_type = PseudoJet{Float64}
     end
     events::Vector{Vector{jet_type}} = read_final_state_particles(args[:file],
                                                                   maxevents = args[:maxevents],
                                                                   skipevents = args[:skip],
                                                                   T = jet_type)
     if isnothing(args[:algorithm]) && isnothing(args[:power])
-        @warn "Neither algorithm nor power specified, defaulting to AntiKt"
+        @warn "Neither algorithm nor power specified, defaulting to pp event AntiKt"
         args[:algorithm] = JetAlgorithm.AntiKt
     end
     jet_process(events, distance = args[:distance], algorithm = args[:algorithm],

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -266,7 +266,7 @@ function inclusive_jets(clusterseq::ClusterSequence{U}; ptmin = 0.0,
         jet = clusterseq.jets[iparent_jet]
         if pt2(jet) >= pt2min
             @debug "Added inclusive jet index $iparent_jet"
-            if T == U
+            if T <: U
                 push!(jets_local, jet)
             else
                 push!(jets_local,

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -148,11 +148,12 @@ ClusterSequence(algorithm::JetAlgorithm.Algorithm, p::Real, R::Float64, strategy
                        Qtot)
 end
 
-ClusterSequence{T}(algorithm::JetAlgorithm.Algorithm, p::Real, R::Float64, strategy::RecoStrategy.Strategy, jets::Vector{T}, history, Qtot) where {T <: FourMomentum} = begin
+function ClusterSequence{T}(algorithm::JetAlgorithm.Algorithm, p::Real, R::Float64,
+                            strategy::RecoStrategy.Strategy, jets::Vector{T}, history,
+                            Qtot) where {T <: FourMomentum}
     ClusterSequence{T}(algorithm, Float64(p), R, strategy, jets, length(jets), history,
                        Qtot)
 end
-
 
 """
     add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, dij)

--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -148,6 +148,12 @@ ClusterSequence(algorithm::JetAlgorithm.Algorithm, p::Real, R::Float64, strategy
                        Qtot)
 end
 
+ClusterSequence{T}(algorithm::JetAlgorithm.Algorithm, p::Real, R::Float64, strategy::RecoStrategy.Strategy, jets::Vector{T}, history, Qtot) where {T <: FourMomentum} = begin
+    ClusterSequence{T}(algorithm, Float64(p), R, strategy, jets, length(jets), history,
+                       Qtot)
+end
+
+
 """
     add_step_to_history!(clusterseq::ClusterSequence, parent1, parent2, jetp_index, dij)
 

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -248,7 +248,7 @@ function ee_genkt_algorithm(particles::AbstractArray{T, 1}; p = 1, R = 4.0,
         for i in eachindex(particles)
             push!(recombination_particles,
                   EEjet{ParticleType}(px(particles[i]), py(particles[i]), pz(particles[i]),
-                        energy(particles[i])))
+                                      energy(particles[i])))
         end
     end
 
@@ -299,8 +299,9 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet{T}}, p = 1, R = 4.0,
     # Setup the initial history and get the total energy
     history, Qtot = initial_history(particles)
 
-    clusterseq = ClusterSequence{EEjet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Plain, particles, history,
-                                 Qtot)
+    clusterseq = ClusterSequence{EEjet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Plain,
+                                                      particles, history,
+                                                      Qtot)
 
     # Run over initial pairs of jets to find nearest neighbours
     get_angular_nearest_neighbours!(eereco, algorithm, dij_factor)

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -242,6 +242,8 @@ function ee_genkt_algorithm(particles::AbstractArray{T, 1}; p = 1, R = 4.0,
         recombination_particles = copy(particles)
         sizehint!(recombination_particles, length(particles) * 2)
     else
+        # We don't really know what element type we have here, so we need to
+        # drill down to a component to get that underlying type
         ParticleType = typeof(px(particles[1]))
         recombination_particles = EEjet{ParticleType}[]
         sizehint!(recombination_particles, length(particles) * 2)
@@ -275,7 +277,7 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet{T}}, p = 1, R = 4.0,
     R2 = R^2
 
     # Numerical type?
-    ParticleType = eltype(particles[1])
+    ParticleType = T
 
     # Constant factor for the dij metric and the beam distance function
     if algorithm == JetAlgorithm.Durham

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -275,7 +275,7 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet{T}}, p = 1, R = 4.0,
     R2 = R^2
 
     # Numerical type?
-    ParticleType = typeof(particles[1].E)
+    ParticleType = eltype(particles[1])
 
     # Constant factor for the dij metric and the beam distance function
     if algorithm == JetAlgorithm.Durham

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -236,7 +236,7 @@ function ee_genkt_algorithm(particles::AbstractArray{T, 1}; p = 1, R = 4.0,
         R = 4.0
     end
 
-    if T == EEjet
+    if T <: EEjet
         # recombination_particles will become part of the cluster sequence, so size it for
         # the starting particles and all N recombinations
         recombination_particles = copy(particles)
@@ -261,7 +261,7 @@ function ee_genkt_algorithm(particles::AbstractArray{T, 1}; p = 1, R = 4.0,
 end
 
 """
-    _ee_genkt_algorithm(; particles::Vector{EEjet}, p = 1, R = 4.0,
+    _ee_genkt_algorithm(; particles::Vector{EEjet{T}}, p = 1, R = 4.0,
                        algorithm::JetAlgorithm.Algorithm = JetAlgorithm.Durham,
                        recombine = +)
 

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -273,6 +273,9 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet}, p = 1, R = 4.0,
     # R squared
     R2 = R^2
 
+    # Numerical type?
+    ParticleType = typeof(particles[1].E)
+
     # Constant factor for the dij metric and the beam distance function
     if algorithm == JetAlgorithm.Durham
         dij_factor = 2.0
@@ -289,7 +292,7 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet}, p = 1, R = 4.0,
     # For optimised reconstruction generate an SoA containing the necessary
     # jet information and populate it accordingly
     # We need N slots for this array
-    eereco = StructArray{EERecoJet}(undef, N)
+    eereco = StructArray{EERecoJet{ParticleType}}(undef, N)
     fill_reco_array!(eereco, particles, R2, p)
 
     # Setup the initial history and get the total energy

--- a/src/EEAlgorithm.jl
+++ b/src/EEAlgorithm.jl
@@ -3,8 +3,6 @@
 const large_distance = 16.0 # = 4^2
 const large_dij = 1.0e6
 
-using Infiltrator
-
 """
     angular_distance(eereco, i, j) -> Float64
 
@@ -309,8 +307,6 @@ function _ee_genkt_algorithm(; particles::Vector{EEjet{T}}, p = 1, R = 4.0,
 
     # Only for debugging purposes...
     # ee_check_consistency(clusterseq, clusterseq_index, N, nndist, nndij, nni, "Start")
-
-    #@infiltrate
 
     # Now we can start the main loop
     iter = 0

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -27,13 +27,13 @@ mutable struct EEjet{T <: Real} <: FourMomentum
     _cluster_hist_index::Int
 end
 
-function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Int) where {T <: Real}
+function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T <: Real}
     @muladd p2 = px * px + py * py + pz * pz
     inv_p = @fastmath 1.0 / sqrt(p2)
     EEjet{T}(px, py, pz, E, p2, inv_p, _cluster_hist_index)
 end
 
-EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet{T}(px, py, pz, E, 0)
+EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
 
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
 

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -34,6 +34,7 @@ function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T
 end
 
 EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
+EEjet{T}(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
 
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
 

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -27,14 +27,12 @@ mutable struct EEjet{T <: Real} <: FourMomentum
     _cluster_hist_index::Int
 end
 
-
 """
     Base.eltype(::Type{EEjet{T}}) where T
 
 Return the element type of the `EEjet` struct.
 """
-Base.eltype(::Type{EEjet{T}}) where T = T
-
+Base.eltype(::Type{EEjet{T}}) where {T} = T
 
 """
     EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T <: Real}
@@ -106,8 +104,8 @@ Constructs an `EEjet` object with conversion of the given momentum components
 An `EEjet` object with the momentum components and energy parametrised to type
 `U`.
 """
-EEjet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = EEjet(U(px), U(py), U(pz), U(E), 0)
-
+EEjet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = EEjet(U(px), U(py),
+                                                                         U(pz), U(E), 0)
 
 """
     EEjet(pj::PseudoJet) -> EEjet
@@ -121,7 +119,6 @@ Constructs an `EEjet` object from a given `PseudoJet` object `pj`.
 - An `EEjet` object initialized with the same properties of the given `PseudoJet`.
 """
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
-
 
 p2(eej::EEjet) = eej._p2
 pt2(eej::EEjet) = eej.px^2 + eej.py^2

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -1,34 +1,39 @@
 """
-    struct EEjet
+    struct EEjet{T <: Real} <: FourMomentum
 
-The `EEjet` struct is a 4-momentum object used for the e+e jet reconstruction routines.
+The `EEjet` struct is a 4-momentum object used for the e+e jet reconstruction
+routines. Internal fields are used to track the reconstuction and to cache
+values needed during the execution of the algorithm.
 
 # Fields
-- `px::Float64`: The x-component of the jet momentum.
-- `py::Float64`: The y-component of the jet momentum.
-- `pz::Float64`: The z-component of the jet momentum.
-- `E::Float64`: The energy of the jet.
+- `px::T`: The x-component of the jet momentum.
+- `py::T`: The y-component of the jet momentum.
+- `pz::T`: The z-component of the jet momentum.
+- `E::T`: The energy of the jet.
 - `_cluster_hist_index::Int`: The index of the cluster histogram.
-- `_p2::Float64`: The squared momentum of the jet.
-- `_inv_p::Float64`: The inverse momentum of the jet.
+- `_p2::T`: The squared momentum of the jet.
+- `_inv_p::T`: The inverse momentum of the jet.
+
+# Type Parameters
+- `T <: Real`: The type of the numerical values.
 """
-mutable struct EEjet <: FourMomentum
-    px::Float64
-    py::Float64
-    pz::Float64
-    E::Float64
-    _p2::Float64
-    _inv_p::Float64
+mutable struct EEjet{T <: Real} <: FourMomentum
+    px::T
+    py::T
+    pz::T
+    E::T
+    _p2::T
+    _inv_p::T
     _cluster_hist_index::Int
 end
 
-function EEjet(px::Real, py::Real, pz::Real, E::Real, _cluster_hist_index::Int)
+function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Int) where {T <: Real}
     @muladd p2 = px * px + py * py + pz * pz
     inv_p = @fastmath 1.0 / sqrt(p2)
-    EEjet(px, py, pz, E, p2, inv_p, _cluster_hist_index)
+    EEjet{T}(px, py, pz, E, p2, inv_p, _cluster_hist_index)
 end
 
-EEjet(px::Real, py::Real, pz::Real, E::Real) = EEjet(px, py, pz, E, 0)
+EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet{T}(px, py, pz, E, 0)
 
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
 
@@ -87,15 +92,31 @@ function show(io::IO, eej::EEjet)
           " cluster_hist_index: ", eej._cluster_hist_index, ")")
 end
 
-# Optimised reconstruction struct for e+e jets
+"""
+    mutable struct EERecoJet{T <: Real}
 
-mutable struct EERecoJet
+Optimised struct for e+e jets reconstruction, to be used with StructArrays.
+
+# Fields
+- `index::Int`: The index of the jet.
+- `nni::Int`: The nearest neighbour index.
+- `nndist::T`: The distance to the nearest neighbour.
+- `dijdist::T`: The distance between jets.
+- `nx::T`: The x-component of the jet's momentum.
+- `ny::T`: The y-component of the jet's momentum.
+- `nz::T`: The z-component of the jet's momentum.
+- `E2p::T`: The energy-to-momentum ratio of the jet.
+
+# Type Parameters
+- `T <: Real`: The type of the numerical values.
+"""
+mutable struct EERecoJet{T <: Real}
     index::Int
     nni::Int
-    nndist::Float64
-    dijdist::Float64
-    nx::Float64
-    ny::Float64
-    nz::Float64
-    E2p::Float64
+    nndist::T
+    dijdist::T
+    nx::T
+    ny::T
+    nz::T
+    E2p::T
 end

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -2,7 +2,7 @@
     struct EEjet{T <: Real} <: FourMomentum
 
 The `EEjet` struct is a 4-momentum object used for the e+e jet reconstruction
-routines. Internal fields are used to track the reconstuction and to cache
+routines. Internal fields are used to track the reconstruction and to cache
 values needed during the execution of the algorithm.
 
 # Fields
@@ -105,7 +105,7 @@ Optimised struct for e+e jets reconstruction, to be used with StructArrays.
 - `nx::T`: The x-component of the jet's momentum.
 - `ny::T`: The y-component of the jet's momentum.
 - `nz::T`: The z-component of the jet's momentum.
-- `E2p::T`: The energy-to-momentum ratio of the jet.
+- `E2p::T`: The energy raised to the power of 2p for this jet.
 
 # Type Parameters
 - `T <: Real`: The type of the numerical values.

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -27,6 +27,14 @@ mutable struct EEjet{T <: Real} <: FourMomentum
     _cluster_hist_index::Int
 end
 
+
+"""
+    Base.eltype(::Type{EEjet{T}}) where T
+
+Return the element type of the `EEjet` struct.
+"""
+Base.eltype(::Type{EEjet{T}}) where T = T
+
 function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T <: Real}
     @muladd p2 = px * px + py * py + pz * pz
     inv_p = @fastmath 1.0 / sqrt(p2)

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -33,8 +33,11 @@ function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T
     EEjet{T}(px, py, pz, E, p2, inv_p, _cluster_hist_index)
 end
 
+# Constructor with type T passes through without history index
 EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
-EEjet{T}(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
+
+# Constructor with type U does type conversion before initialising
+EEjet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = EEjet(U(px), U(py), U(pz), U(E), 0)
 
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
 

--- a/src/EEjet.jl
+++ b/src/EEjet.jl
@@ -35,19 +35,93 @@ Return the element type of the `EEjet` struct.
 """
 Base.eltype(::Type{EEjet{T}}) where T = T
 
+
+"""
+    EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T <: Real}
+
+Constructs an `EEjet` object with the given momentum components `px`, `py`,
+`pz`, energy `E`, and cluster histogram index `_cluster_hist_index`.
+
+The constructed EEjet object will be parametrised by the type `T`.
+
+# Arguments
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy of the jet.
+- `_cluster_hist_index::Integer`: The index of the cluster histogram.
+
+# Returns
+- The initialised `EEjet` object.
+
+# Note
+- `T` must be a subtype of `Real`.
+- The `@muladd` macro is used to perform fused multiply-add operations for
+  computing `p2`.
+- The `@fastmath` macro is used to allow the compiler to perform optimizations
+  for computing `inv_p`.
+"""
 function EEjet(px::T, py::T, pz::T, E::T, _cluster_hist_index::Integer) where {T <: Real}
     @muladd p2 = px * px + py * py + pz * pz
     inv_p = @fastmath 1.0 / sqrt(p2)
     EEjet{T}(px, py, pz, E, p2, inv_p, _cluster_hist_index)
 end
 
-# Constructor with type T passes through without history index
+"""
+    EEjet(px::T, py::T, pz::T, E::T) where {T <: Real}
+
+Constructs an `EEjet` object with the given momentum components `px`, `py`,
+`pz`, energy `E`, and the cluster histogram index set to zero.
+
+The constructed EEjet object will be parametrised by the type `T`.
+
+# Arguments
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy of the jet.
+
+# Returns
+- The initialised `EEjet` object.
+"""
 EEjet(px::T, py::T, pz::T, E::T) where {T <: Real} = EEjet(px, py, pz, E, 0)
 
-# Constructor with type U does type conversion before initialising
+"""
+    EEjet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real}
+
+Constructs an `EEjet` object with conversion of the given momentum components
+(`px`, `py`, `pz`) and energy (`E`) from type `T` to type `U`.
+
+# Arguments
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy.
+
+# Type Parameters
+- `T <: Real`: The type of the input momentum components and energy.
+- `U <: Real`: The type to which the input values will be converted
+
+# Returns
+An `EEjet` object with the momentum components and energy parametrised to type
+`U`.
+"""
 EEjet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = EEjet(U(px), U(py), U(pz), U(E), 0)
 
+
+"""
+    EEjet(pj::PseudoJet) -> EEjet
+
+Constructs an `EEjet` object from a given `PseudoJet` object `pj`.
+
+# Arguments
+- `pj::PseudoJet`: A `PseudoJet` object used to create the `EEjet`.
+
+# Returns
+- An `EEjet` object initialized with the same properties of the given `PseudoJet`.
+"""
 EEjet(pj::PseudoJet) = EEjet(px(pj), py(pj), pz(pj), energy(pj), cluster_hist_index(pj))
+
 
 p2(eej::EEjet) = eej._p2
 pt2(eej::EEjet) = eej.px^2 + eej.py^2

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -230,7 +230,7 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
     # Integer p if possible
     p = (round(p) == p) ? Int(p) : p
 
-    if T isa PseudoJet
+    if T <: PseudoJet
         # recombination_particles will become part of the cluster sequence, so size it for
         # the starting particles and all N recombinations
         recombination_particles = copy(particles)
@@ -243,7 +243,7 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
         sizehint!(recombination_particles, length(particles) * 2)
         for i in eachindex(particles)
             push!(recombination_particles,
-                  PseudoJet(px(particles[i]), py(particles[i]), pz(particles[i]),
+                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]), pz(particles[i]),
                             energy(particles[i])))
         end
     end
@@ -255,12 +255,12 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
 end
 
 """
-    _plain_jet_reconstruct(; particles::Vector{PseudoJet}, p = -1, R = 1.0, recombine = +)
+    _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1.0, recombine = +)
 
 This is the internal implementation of jet reconstruction using the plain
 algorithm. It takes a vector of `particles` representing the input particles and
 reconstructs jets based on the specified parameters. Here the particles must be
-of type `PseudoJet`.
+of type `PseudoJet{T}`.
 
 Users of the package should use the `plain_jet_reconstruct` function as their
 entry point to this jet reconstruction.

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -281,7 +281,7 @@ generalised k_t algorithm.
 """
 function _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1.0,
                                 algorithm::JetAlgorithm.Algorithm = JetAlgorithm.AntiKt,
-                                recombine = +) where T <: Real
+                                recombine = +) where {T <: Real}
     # Bounds
     N::Int = length(particles)
     # Parameters
@@ -308,8 +308,10 @@ function _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1
     # Current implementation mutates the particles vector, so need to copy it
     # for the cluster sequence (there is too much copying happening, so this
     # needs to be rethought and reoptimised)
-    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Plain, particles, history,
-                                 Qtot)
+    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R,
+                                                          RecoStrategy.N2Plain, particles,
+                                                          history,
+                                                          Qtot)
 
     # Initialize nearest neighbours
     @simd for i in 1:N

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -236,6 +236,8 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
         recombination_particles = copy(particles)
         sizehint!(recombination_particles, length(particles) * 2)
     else
+        # We don't really know what element type we have here, so we need to
+        # drill down to a component to get that underlying type
         ParticleType = typeof(px(particles[1]))
         recombination_particles = PseudoJet{ParticleType}[]
         sizehint!(recombination_particles, length(particles) * 2)
@@ -288,7 +290,7 @@ function _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1
     R2 = R^2
 
     # Numerical type for this reconstruction
-    ParticleType = eltype(particles[1])
+    ParticleType = T
 
     # Optimised compact arrays for determining the next merge step
     # We make sure these arrays are type stable - have seen issues where, depending on the values

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -243,8 +243,9 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
         sizehint!(recombination_particles, length(particles) * 2)
         for i in eachindex(particles)
             push!(recombination_particles,
-                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]), pz(particles[i]),
-                            energy(particles[i])))
+                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]),
+                                          pz(particles[i]),
+                                          energy(particles[i])))
         end
     end
 

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -230,13 +230,14 @@ function plain_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
     # Integer p if possible
     p = (round(p) == p) ? Int(p) : p
 
-    if T == PseudoJet
+    if T isa PseudoJet
         # recombination_particles will become part of the cluster sequence, so size it for
         # the starting particles and all N recombinations
         recombination_particles = copy(particles)
         sizehint!(recombination_particles, length(particles) * 2)
     else
-        recombination_particles = PseudoJet[]
+        ParticleType = typeof(px(particles[1]))
+        recombination_particles = PseudoJet{ParticleType}[]
         sizehint!(recombination_particles, length(particles) * 2)
         for i in eachindex(particles)
             push!(recombination_particles,
@@ -278,23 +279,26 @@ generalised k_t algorithm.
 - `clusterseq`: The resulting `ClusterSequence` object representing the
   reconstructed jets.
 """
-function _plain_jet_reconstruct(; particles::Vector{PseudoJet}, p = -1, R = 1.0,
+function _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1.0,
                                 algorithm::JetAlgorithm.Algorithm = JetAlgorithm.AntiKt,
-                                recombine = +)
+                                recombine = +) where T <: Real
     # Bounds
     N::Int = length(particles)
     # Parameters
     R2 = R^2
 
+    # Numerical type?
+    ParticleType = typeof(particles[1].E)
+
     # Optimised compact arrays for determining the next merge step
     # We make sure these arrays are type stable - have seen issues where, depending on the values
     # returned by the methods, they can become unstable and performance degrades
-    kt2_array::Vector{Float64} = pt2.(particles) .^ p
-    phi_array::Vector{Float64} = phi.(particles)
-    rapidity_array::Vector{Float64} = rapidity.(particles)
+    kt2_array::Vector{ParticleType} = pt2.(particles) .^ p
+    phi_array::Vector{ParticleType} = phi.(particles)
+    rapidity_array::Vector{ParticleType} = rapidity.(particles)
     nn::Vector{Int} = Vector(1:N) # nearest neighbours
-    nndist::Vector{Float64} = fill(float(R2), N) # geometric distances to the nearest neighbour
-    nndij::Vector{Float64} = zeros(N) # dij metric distance
+    nndist::Vector{ParticleType} = fill(float(R2), N) # geometric distances to the nearest neighbour
+    nndij::Vector{ParticleType} = zeros(N) # dij metric distance
 
     # Maps index from the compact array to the clusterseq jet vector
     clusterseq_index::Vector{Int} = collect(1:N)
@@ -304,7 +308,7 @@ function _plain_jet_reconstruct(; particles::Vector{PseudoJet}, p = -1, R = 1.0,
     # Current implementation mutates the particles vector, so need to copy it
     # for the cluster sequence (there is too much copying happening, so this
     # needs to be rethought and reoptimised)
-    clusterseq = ClusterSequence(algorithm, p, R, RecoStrategy.N2Plain, particles, history,
+    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Plain, particles, history,
                                  Qtot)
 
     # Initialize nearest neighbours

--- a/src/PlainAlgo.jl
+++ b/src/PlainAlgo.jl
@@ -287,8 +287,8 @@ function _plain_jet_reconstruct(; particles::Vector{PseudoJet{T}}, p = -1, R = 1
     # Parameters
     R2 = R^2
 
-    # Numerical type?
-    ParticleType = typeof(particles[1].E)
+    # Numerical type for this reconstruction
+    ParticleType = eltype(particles[1])
 
     # Optimised compact arrays for determining the next merge step
     # We make sure these arrays are type stable - have seen issues where, depending on the values

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -56,31 +56,6 @@ Return the element type of the `PseudoJet` struct.
 Base.eltype(::Type{PseudoJet{T}}) where {T} = T
 
 """
-    PseudoJet(px::T, py::T, pz::T, E::T,
-        _cluster_hist_index::Int,
-        pt2::T) where {T <: Real}
-
-Constructs a PseudoJet object with the given momentum components and energy and
-history index.
-
-# Arguments
-- `px::T`: The x-component of the momentum.
-- `py::T`: The y-component of the momentum.
-- `pz::T`: The z-component of the momentum.
-- `E::T`: The energy.
-- `_cluster_hist_index::Int`: The cluster history index.
-- `pt2::T`: The transverse momentum squared.
-
-# Returns
-A `PseudoJet` object.
-"""
-PseudoJet(px::T, py::T, pz::T, E::T,
-_cluster_hist_index::Int,
-pt2::T) where {T <: Real} = PseudoJet{T}(px,
-                                         py, pz, E, _cluster_hist_index,
-                                         pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
-
-"""
     PseudoJet{T}(px::T, py::T, pz::T, E::T,
         _cluster_hist_index::Int,
         pt2::T) where {T <: Real}
@@ -120,10 +95,24 @@ Constructs a PseudoJet object with the given momentum components and energy.
 A PseudoJet object, with type parameter `T`.
 """
 PseudoJet(px::T, py::T,
-pz::T, E::T) where {T <: Real} = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
+pz::T, E::T) where {T <: Real} = PseudoJet{T}(px, py, pz, E, 0, px^2 + py^2)
 
 """
     PseudoJet{U}(px::T, py::T, pz::T, E::T) where T <: Real, U <: Real
+
+Constructs a PseudoJet object with the given momentum components and energy,
+parameterised by `U`.
+
+# Arguments
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy.
+
+- U <: Real: The type parameter for the PseudoJet object.
+
+# Returns
+A PseudoJet object, with type parameter `U`.
 """
 PseudoJet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = PseudoJet{U}(U(px),
                                                                                     U(py),

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -18,7 +18,7 @@ const _invalid_phi = -100.0
 const _invalid_rap = -1.e200
 
 """
-    mutable struct PseudoJet <: FourMomentum
+    mutable struct PseudoJet{T <: Real} <: FourMomentum
 
 The `PseudoJet` struct represents a pseudojet, a four-momentum object used in
 jet reconstruction algorithms. Additional information for the link back into the
@@ -26,70 +26,70 @@ history of the clustering is stored in the `_cluster_hist_index` field. There is
 caching of the more expensive calculations for rapidity and azimuthal angle.
 
 # Fields
-- `px::Float64`: The x-component of the momentum.
-- `py::Float64`: The y-component of the momentum.
-- `pz::Float64`: The z-component of the momentum.
-- `E::Float64`: The energy component of the momentum.
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy component of the momentum.
 - `_cluster_hist_index::Int`: The index of the cluster history.
-- `_pt2::Float64`: The squared transverse momentum.
-- `_inv_pt2::Float64`: The inverse squared transverse momentum.
-- `_rap::Float64`: The rapidity.
-- `_phi::Float64`: The azimuthal angle.
+- `_pt2::T`: The squared transverse momentum.
+- `_inv_pt2::T`: The inverse squared transverse momentum.
+- `_rap::T`: The rapidity.
+- `_phi::T`: The azimuthal angle.
 
 """
-mutable struct PseudoJet <: FourMomentum
-    px::Float64
-    py::Float64
-    pz::Float64
-    E::Float64
+mutable struct PseudoJet{T <: Real} <: FourMomentum
+    px::T
+    py::T
+    pz::T
+    E::T
     _cluster_hist_index::Int
-    _pt2::Float64
-    _inv_pt2::Float64
-    _rap::Float64
-    _phi::Float64
+    _pt2::T
+    _inv_pt2::T
+    _rap::T
+    _phi::T
 end
 
 """
-    PseudoJet(px::Real, py::Real, pz::Real, E::Real,
+    PseudoJet(px::T, py::T, pz::T, E::T,
         _cluster_hist_index::Int,
-        pt2::Real)
+        pt2::T) where {T <: Real}
 
 Constructs a PseudoJet object with the given momentum components and energy and
 history index.
 
 # Arguments
-- `px::Real`: The x-component of the momentum.
-- `py::Real`: The y-component of the momentum.
-- `pz::Real`: The z-component of the momentum.
-- `E::Real`: The energy.
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy.
 - `_cluster_hist_index::Int`: The cluster history index.
-- `pt2::Real`: The transverse momentum squared.
+- `pt2::T`: The transverse momentum squared.
 
 # Returns
 A `PseudoJet` object.
 """
-PseudoJet(px::Real, py::Real, pz::Real, E::Real,
+PseudoJet(px::T, py::T, pz::T, E::T,
 _cluster_hist_index::Int,
-pt2::Real) = PseudoJet(px,
-                       py, pz, E, _cluster_hist_index,
-                       pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
+pt2::T) where {T <: Real} = PseudoJet{T}(px,
+                                         py, pz, E, _cluster_hist_index,
+                                         pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
 
 """
-    PseudoJet(px::Real, py::Real, pz::Real, E::Real)
+    PseudoJet(px::T, py::T, pz::T, E::T) where T <: Real
 
 Constructs a PseudoJet object with the given momentum components and energy.
 
 # Arguments
-- `px::Real`: The x-component of the momentum.
-- `py::Real`: The y-component of the momentum.
-- `pz::Real`: The z-component of the momentum.
-- `E::Real`: The energy.
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy.
 
 # Returns
 A PseudoJet object.
 """
-PseudoJet(px::Real, py::Real,
-pz::Real, E::Real) = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
+PseudoJet(px::T, py::T,
+pz::T, E::T) where {T <: Real} = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
 
 import Base.show
 """

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -50,6 +50,13 @@ mutable struct PseudoJet{T <: Real} <: FourMomentum
 end
 
 """
+    Base.eltype(::Type{PseudoJet{T}}) where T
+
+Return the element type of the `PseudoJet` struct.
+"""
+Base.eltype(::Type{PseudoJet{T}}) where T = T
+
+"""
     PseudoJet(px::T, py::T, pz::T, E::T,
         _cluster_hist_index::Int,
         pt2::T) where {T <: Real}

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -35,7 +35,6 @@ caching of the more expensive calculations for rapidity and azimuthal angle.
 - `_inv_pt2::T`: The inverse squared transverse momentum.
 - `_rap::T`: The rapidity.
 - `_phi::T`: The azimuthal angle.
-
 """
 mutable struct PseudoJet{T <: Real} <: FourMomentum
     px::T
@@ -81,6 +80,25 @@ PseudoJet(px::T, py::T, pz::T, E::T,
                                             py, pz, E, _cluster_hist_index,
                                              pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
 
+"""
+    PseudoJet{T}(px::T, py::T, pz::T, E::T,
+        _cluster_hist_index::Int,
+        pt2::T) where {T <: Real}
+
+Constructs a parametrised PseudoJet object with the given momentum components
+and energy and history index.
+
+# Arguments
+- `px::T`: The x-component of the momentum.
+- `py::T`: The y-component of the momentum.
+- `pz::T`: The z-component of the momentum.
+- `E::T`: The energy.
+- `_cluster_hist_index::Int`: The cluster history index.
+- `pt2::T`: The transverse momentum squared.
+
+# Returns
+A `PseudoJet` object.
+"""
 PseudoJet{T}(px::T, py::T, pz::T, E::T,
             _cluster_hist_index::Int,
             pt2::T) where {T <: Real} = PseudoJet{T}(px,
@@ -99,12 +117,15 @@ Constructs a PseudoJet object with the given momentum components and energy.
 - `E::T`: The energy.
 
 # Returns
-A PseudoJet object.
+A PseudoJet object, with type parameter `T`.
 """
 PseudoJet(px::T, py::T,
 pz::T, E::T) where {T <: Real} = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
-PseudoJet{T}(px::T, py::T,
-pz::T, E::T) where {T <: Real} = PseudoJet{T}(px, py, pz, E, 0, px^2 + py^2)
+
+"""
+    PseudoJet{U}(px::T, py::T, pz::T, E::T) where T <: Real, U <: Real
+"""
+PseudoJet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = PseudoJet{U}(U(px), U(py), U(pz), U(E), 0, U(px^2 + py^2))
 
 
 import Base.show

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -69,10 +69,16 @@ history index.
 A `PseudoJet` object.
 """
 PseudoJet(px::T, py::T, pz::T, E::T,
-_cluster_hist_index::Int,
-pt2::T) where {T <: Real} = PseudoJet{T}(px,
-                                         py, pz, E, _cluster_hist_index,
-                                         pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
+    _cluster_hist_index::Int,
+    pt2::T) where {T <: Real} = PseudoJet{T}(px,
+                                            py, pz, E, _cluster_hist_index,
+                                             pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
+
+PseudoJet{T}(px::T, py::T, pz::T, E::T,
+            _cluster_hist_index::Int,
+            pt2::T) where {T <: Real} = PseudoJet{T}(px,
+                                                    py, pz, E, _cluster_hist_index,
+                                                    pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
 
 """
     PseudoJet(px::T, py::T, pz::T, E::T) where T <: Real
@@ -90,6 +96,9 @@ A PseudoJet object.
 """
 PseudoJet(px::T, py::T,
 pz::T, E::T) where {T <: Real} = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
+PseudoJet{T}(px::T, py::T,
+pz::T, E::T) where {T <: Real} = PseudoJet{T}(px, py, pz, E, 0, px^2 + py^2)
+
 
 import Base.show
 """

--- a/src/Pseudojet.jl
+++ b/src/Pseudojet.jl
@@ -53,7 +53,7 @@ end
 
 Return the element type of the `PseudoJet` struct.
 """
-Base.eltype(::Type{PseudoJet{T}}) where T = T
+Base.eltype(::Type{PseudoJet{T}}) where {T} = T
 
 """
     PseudoJet(px::T, py::T, pz::T, E::T,
@@ -75,10 +75,10 @@ history index.
 A `PseudoJet` object.
 """
 PseudoJet(px::T, py::T, pz::T, E::T,
-    _cluster_hist_index::Int,
-    pt2::T) where {T <: Real} = PseudoJet{T}(px,
-                                            py, pz, E, _cluster_hist_index,
-                                             pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
+_cluster_hist_index::Int,
+pt2::T) where {T <: Real} = PseudoJet{T}(px,
+                                         py, pz, E, _cluster_hist_index,
+                                         pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
 
 """
     PseudoJet{T}(px::T, py::T, pz::T, E::T,
@@ -100,10 +100,10 @@ and energy and history index.
 A `PseudoJet` object.
 """
 PseudoJet{T}(px::T, py::T, pz::T, E::T,
-            _cluster_hist_index::Int,
-            pt2::T) where {T <: Real} = PseudoJet{T}(px,
-                                                    py, pz, E, _cluster_hist_index,
-                                                    pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
+_cluster_hist_index::Int,
+pt2::T) where {T <: Real} = PseudoJet{T}(px,
+                                         py, pz, E, _cluster_hist_index,
+                                         pt2, 1.0 / pt2, _invalid_rap, _invalid_phi)
 
 """
     PseudoJet(px::T, py::T, pz::T, E::T) where T <: Real
@@ -125,8 +125,12 @@ pz::T, E::T) where {T <: Real} = PseudoJet(px, py, pz, E, 0, px^2 + py^2)
 """
     PseudoJet{U}(px::T, py::T, pz::T, E::T) where T <: Real, U <: Real
 """
-PseudoJet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = PseudoJet{U}(U(px), U(py), U(pz), U(E), 0, U(px^2 + py^2))
-
+PseudoJet{U}(px::T, py::T, pz::T, E::T) where {T <: Real, U <: Real} = PseudoJet{U}(U(px),
+                                                                                    U(py),
+                                                                                    U(pz),
+                                                                                    U(E), 0,
+                                                                                    U(px^2 +
+                                                                                      py^2))
 
 import Base.show
 """

--- a/src/Substructure.jl
+++ b/src/Substructure.jl
@@ -142,7 +142,8 @@ The method stops at the first jet satisfying the mass and distance thresholds.
 # Returns:
 - `PseudoJet`: The jet (or subjet) satisfying the mass drop conditions, if tagging is successful, otherwise a zero-momentum PseudoJet
 """
-function mass_drop(jet::PseudoJet, clusterseq::ClusterSequence, tag::MassDropTagger)
+function mass_drop(jet::PseudoJet{T}, clusterseq::ClusterSequence,
+                   tag::MassDropTagger) where {T <: Real}
     all_jets = clusterseq.jets
     hist = clusterseq.history
 
@@ -188,11 +189,11 @@ This function reclusters the jet and iteratively checks the soft-drop condition 
 # Returns:
 - `PseudoJet`: Groomed jet or zero-momentum PseudoJet if grooming fails
 """
-function soft_drop(jet::PseudoJet, clusterseq::ClusterSequence,
-                   tag::SoftDropTagger)
+function soft_drop(jet::PseudoJet{T}, clusterseq::ClusterSequence,
+                   tag::SoftDropTagger) where {T <: Real}
     rad = tag.cluster_rad
     new_clusterseq = recluster(jet, clusterseq; R = rad, algorithm = JetAlgorithm.CA)
-    new_jet = sort!(inclusive_jets(new_clusterseq; T = PseudoJet), by = pt2, rev = true)[1]
+    new_jet = sort!(inclusive_jets(new_clusterseq; T = PseudoJet{T}), by = pt2, rev = true)[1]
 
     all_jets = new_clusterseq.jets
     hist = new_clusterseq.history
@@ -238,10 +239,12 @@ Filters a jet to retain only the hardest subjets based on a specified radius and
 # Returns:
 - `PseudoJet`: Filtered jet composed of the hardest subjets
 """
-function jet_filtering(jet::PseudoJet, clusterseq::ClusterSequence, filter::JetFilter)
+function jet_filtering(jet::PseudoJet{T}, clusterseq::ClusterSequence,
+                       filter::JetFilter) where {T <: Real}
     rad = filter.filter_radius
     new_clusterseq = recluster(jet, clusterseq; R = rad, algorithm = JetAlgorithm.CA)
-    reclustered = sort!(inclusive_jets(new_clusterseq; T = PseudoJet), by = pt2, rev = true)
+    reclustered = sort!(inclusive_jets(new_clusterseq; T = PseudoJet{T}), by = pt2,
+                        rev = true)
 
     n = length(reclustered) <= filter.num_hardest_jets ? length(reclustered) :
         filter.num_hardest_jets
@@ -265,13 +268,15 @@ Trims a jet by removing subjets with transverse momentum below a specified fract
 # Returns:
 - `PseudoJet`: Trimmed jet composed of retained subjets
 """
-function jet_trimming(jet::PseudoJet, clusterseq::ClusterSequence, trim::JetTrim)
+function jet_trimming(jet::PseudoJet{T}, clusterseq::ClusterSequence,
+                      trim::JetTrim) where {T <: Real}
     rad = trim.trim_radius
     alg = trim.recluster_method
     frac2 = trim.trim_fraction^2
 
     new_clusterseq = recluster(jet, clusterseq; R = rad, algorithm = alg)
-    reclustered = sort!(inclusive_jets(new_clusterseq; T = PseudoJet), by = pt2, rev = true)
+    reclustered = sort!(inclusive_jets(new_clusterseq; T = PseudoJet{T}), by = pt2,
+                        rev = true)
 
     hard = Vector{PseudoJet}(undef, 0)
     for item in reclustered

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -374,17 +374,18 @@ function tiled_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
     (p, algorithm) = get_algorithm_power_consistency(p = p, algorithm = algorithm)
 
     # If we have PseudoJets, we can just call the main algorithm...
-    if T == PseudoJet
+    if T isa PseudoJet
         # recombination_particles will become part of the cluster sequence, so size it for
         # the starting particles and all N recombinations
         recombination_particles = copy(particles)
         sizehint!(recombination_particles, length(particles) * 2)
     else
-        recombination_particles = PseudoJet[]
+        ParticleType = typeof(px(particles[1]))
+        recombination_particles = PseudoJet{ParticleType}[]
         sizehint!(recombination_particles, length(particles) * 2)
         for i in eachindex(particles)
             push!(recombination_particles,
-                  PseudoJet(px(particles[i]), py(particles[i]), pz(particles[i]),
+                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]), pz(particles[i]),
                             energy(particles[i])))
         end
     end
@@ -421,9 +422,9 @@ of data types are done.
 tiled_jet_reconstruct(particles::Vector{PseudoJet}; p = 1, R = 1.0, recombine = +)
 ```
 """
-function _tiled_jet_reconstruct(particles::Vector{PseudoJet}; p::Real = -1, R = 1.0,
+function _tiled_jet_reconstruct(particles::Vector{PseudoJet{T}}; p::Real = -1, R = 1.0,
                                 algorithm::JetAlgorithm.Algorithm = JetAlgorithm.AntiKt,
-                                recombine = +)
+                                recombine = +) where T <: Real
     # Bounds
     N::Int = length(particles)
 
@@ -439,13 +440,16 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet}; p::Real = -1, R = 
     R2::Float64 = R * R
     p = (round(p) == p) ? Int(p) : p # integer p if possible
 
+    # Numerical type?
+    ParticleType = typeof(particles[1].E)
+
     # This will be used quite deep inside loops, so declare it here so that
     # memory (de)allocation gets done only once
     tile_union = Vector{Int}(undef, 3 * _n_tile_neighbours)
 
     # Container for pseudojets, sized for all initial particles, plus all of the
     # merged jets that can be created during reconstruction
-    jets = PseudoJet[]
+    jets = PseudoJet{ParticleType}[]
     sizehint!(jets, N * 2)
     resize!(jets, N)
 
@@ -456,7 +460,7 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet}; p::Real = -1, R = 
     history, Qtot = initial_history(jets)
 
     # Now get the tiling setup
-    _eta = Vector{Float64}(undef, length(particles))
+    _eta = Vector{ParticleType}(undef, length(particles))
     for ijet in 1:length(particles)
         _eta[ijet] = rapidity(particles[ijet])
     end
@@ -464,7 +468,7 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet}; p::Real = -1, R = 
     tiling = Tiling(setup_tiling(_eta, R))
 
     # ClusterSequence is the struct that holds the state of the reconstruction
-    clusterseq = ClusterSequence(algorithm, p, R, RecoStrategy.N2Tiled, jets, history, Qtot)
+    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Tiled, jets, history, Qtot)
 
     # Tiled jets is a structure that has additional variables for tracking which tile a jet is in
     tiledjets = similar(clusterseq.jets, TiledJet)

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -374,7 +374,7 @@ function tiled_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
     (p, algorithm) = get_algorithm_power_consistency(p = p, algorithm = algorithm)
 
     # If we have PseudoJets, we can just call the main algorithm...
-    if T isa PseudoJet
+    if T <: PseudoJet
         # recombination_particles will become part of the cluster sequence, so size it for
         # the starting particles and all N recombinations
         recombination_particles = copy(particles)

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -380,6 +380,8 @@ function tiled_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
         recombination_particles = copy(particles)
         sizehint!(recombination_particles, length(particles) * 2)
     else
+        # We don't really know what element type we have here, so we need to
+        # drill down to a component to get that underlying type
         ParticleType = typeof(px(particles[1]))
         recombination_particles = PseudoJet{ParticleType}[]
         sizehint!(recombination_particles, length(particles) * 2)
@@ -442,7 +444,7 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet{T}}; p::Real = -1, R
     p = (round(p) == p) ? Int(p) : p # integer p if possible
 
     # Numerical type for this reconstruction
-    ParticleType = eltype(particles[1])
+    ParticleType = T
 
     # This will be used quite deep inside loops, so declare it here so that
     # memory (de)allocation gets done only once

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -385,8 +385,9 @@ function tiled_jet_reconstruct(particles::AbstractArray{T, 1}; p::Union{Real, No
         sizehint!(recombination_particles, length(particles) * 2)
         for i in eachindex(particles)
             push!(recombination_particles,
-                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]), pz(particles[i]),
-                            energy(particles[i])))
+                  PseudoJet{ParticleType}(px(particles[i]), py(particles[i]),
+                                          pz(particles[i]),
+                                          energy(particles[i])))
         end
     end
 
@@ -424,7 +425,7 @@ tiled_jet_reconstruct(particles::Vector{PseudoJet}; p = 1, R = 1.0, recombine = 
 """
 function _tiled_jet_reconstruct(particles::Vector{PseudoJet{T}}; p::Real = -1, R = 1.0,
                                 algorithm::JetAlgorithm.Algorithm = JetAlgorithm.AntiKt,
-                                recombine = +) where T <: Real
+                                recombine = +) where {T <: Real}
     # Bounds
     N::Int = length(particles)
 
@@ -468,7 +469,9 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet{T}}; p::Real = -1, R
     tiling = Tiling(setup_tiling(_eta, R))
 
     # ClusterSequence is the struct that holds the state of the reconstruction
-    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R, RecoStrategy.N2Tiled, jets, history, Qtot)
+    clusterseq = ClusterSequence{PseudoJet{ParticleType}}(algorithm, p, R,
+                                                          RecoStrategy.N2Tiled, jets,
+                                                          history, Qtot)
 
     # Tiled jets is a structure that has additional variables for tracking which tile a jet is in
     tiledjets = similar(clusterseq.jets, TiledJet)

--- a/src/TiledAlgoLL.jl
+++ b/src/TiledAlgoLL.jl
@@ -440,8 +440,8 @@ function _tiled_jet_reconstruct(particles::Vector{PseudoJet{T}}; p::Real = -1, R
     R2::Float64 = R * R
     p = (round(p) == p) ? Int(p) : p # integer p if possible
 
-    # Numerical type?
-    ParticleType = typeof(particles[1].E)
+    # Numerical type for this reconstruction
+    ParticleType = eltype(particles[1])
 
     # This will be used quite deep inside loops, so declare it here so that
     # memory (de)allocation gets done only once

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -21,7 +21,8 @@ the particles of a particular event. In particular T can be `PseudoJet` or
 a `LorentzVector` type. Note, if T is not `PseudoJet`, the order of the
 arguments in the constructor must be `(t, x, y, z)`.
 """
-function read_final_state_particles(fname; maxevents = -1, skipevents = 0, T = PseudoJet)
+function read_final_state_particles(fname; maxevents = -1, skipevents = 0,
+                                    T = PseudoJet{Float64})
     f = open(fname)
     if endswith(fname, ".gz")
         @debug "Reading gzipped file $fname"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,9 @@ function main()
     include("test-pp-reconstruction.jl")
     include("test-ee-reconstruction.jl")
 
+    # Also test reconstruction with Float32
+    include("test-f32-reconstruction.jl")
+
     # Compare inputting data in PseudoJet with using a LorentzVector
     do_test_compare_types(RecoStrategy.N2Plain, algname = pp_algorithms[-1], power = -1)
     do_test_compare_types(RecoStrategy.N2Tiled, algname = pp_algorithms[-1], power = -1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,7 +158,7 @@ function do_test_compare_types(strategy::RecoStrategy.Strategy;
 
     # Now run our jet reconstruction...
     # From PseudoJets
-    events::Vector{Vector{PseudoJet}} = read_final_state_particles(events_file_pp)
+    events::Vector{Vector{PseudoJet{Float64}}} = read_final_state_particles(events_file_pp)
     jet_collection = FinalJets[]
     for (ievt, event) in enumerate(events)
         finaljets = final_jets(inclusive_jets(jet_reconstruction(event, R = distance,

--- a/test/test-constituents.jl
+++ b/test/test-constituents.jl
@@ -21,7 +21,7 @@ event_no = 1
 cluster_seq = jet_reconstruct(events[event_no], p = 1, R = 1.0)
 
 # Retrieve the exclusive pj_jets, but as `PseudoJet` types
-pj_jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet)
+pj_jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet{Float64})
 
 @testset "Jet constituents" begin
     @testset "Constituents of jet number $(event_no)" begin

--- a/test/test-f32-reconstruction.jl
+++ b/test/test-f32-reconstruction.jl
@@ -1,0 +1,20 @@
+# Tests of reconstruction algorithms in Float32
+
+include("common.jl")
+
+durham_njets3_f32 = ComparisonTest(events_file_ee,
+                                   joinpath(@__DIR__, "data",
+                                            "jet-collections-fastjet-njets3-Durham-eeH.json.gz"),
+                                   JetAlgorithm.Durham, RecoStrategy.N2Plain, 1, 4.0,
+                                   (cs) -> exclusive_jets(cs; njets = 3),
+                                   "exclusive njets Float32", Float32)
+
+run_reco_test(durham_njets3_f32)
+
+antikt_pcut_f32 = ComparisonTest(events_file_pp,
+                                 joinpath(@__DIR__, "data",
+                                          "jet-collections-fastjet-inclusive-AntiKt.json.gz"),
+                                 JetAlgorithm.AntiKt, RecoStrategy.N2Tiled, -1, 0.4,
+                                 (cs) -> inclusive_jets(cs; ptmin = 5.0),
+                                 "inclusive-float32", Float32)
+run_reco_test(antikt_pcut_f32)

--- a/test/test-substructure.jl
+++ b/test/test-substructure.jl
@@ -36,7 +36,7 @@ for m in keys(methods)
     @testset "$testname" begin
         for (ievt, evt) in enumerate(events)
             cluster_seq = jet_reconstruct(evt, p = 0, R = 1.0)
-            jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet)
+            jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet{Float64})
             groomed = sort!([methods[m](jet, cluster_seq, groomer)
                              for jet in jets], by = JetReconstruction.pt2, rev = true)
 


### PR DESCRIPTION
Support is added for general numerical types in this PR. `EEjet` and `PseudoJet` become parametrised on `T <: Real`. `ClusterSequence` stays parametrised on `J <: FourMomentum`, but is it really important to pass the *parametrised* jet collection into the constructor otherwise performance greatly suffers! (i.e., `ClusterSequence{EEjet{Float64}}` not `ClusterSequence{EEjet}`. To support this the `eltype` method is defined for both jet types to return the internal type used.

The `instrumented-jetreco.jl` script gets a new `--type` option that allows a numeric type to be passed for the reconstruction. Added a quick `benchmark.sh` script to run all three main use cases.

Current performance tests shows that we are losing a bit in the $pp$ `N2Tiled` reconstruction, so this needs to be fixed before merging. Performance for Durham $e^+e^-$ and $pp$ `N2Plain` are the same as the current v0.4.3 release.

Testing on M2pro gives

This branch:

```sh
 ~/.julia/dev/JetReconstruction/examples/ [general-numeric-types*] ./benchmark.sh 
pp 14TeV Tiled
Lowest time per event 189.185 μs
pp 14 TeV Plain
Lowest time per event 678.68667 μs
ee H Durham
Lowest time per event 28.38375 μs
```

v0.4.3:

```sh
 ~/.julia/dev/JetReconstruction/examples/ [general-numeric-types] ~/tmp/benchmark.sh
pp 14TeV Tiled
Lowest time per event 176.06666 μs
pp 14 TeV Plain
Lowest time per event 677.14125 μs
ee H Durham
Lowest time per event 27.92792 μs
```

Closes #91 

---
To do:
- [x] Convert `EEjet` to `T <: Real`
- [x] Convert `PseudoJet` to `T <: Real`
- [ ] Convert `TiledJet` to `T <: Real`
- [x] Add option to examples to switch types for the internal representation
  - [x] `instrumented_jetreco.jl`
  - [x] `jetreco.jl`
- [x] Ensure performance is maintained in `Float64` case
  - [x] pp Tiled
  - [x] pp Plain
  - [x] ee
- [ ] Add unit tests for `Float32` reconstruction 
