### PR TITLE
Update signatures in readme to use AbstractVector

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ algorithm and generalised $`k_\text{T}`$ for $`e^+e^-`$.
 The simplest interface is to call:
 
 ```julia
-cs = jet_reconstruct(particles::AbtracyVector{T}; algorithm = JetAlgorithm.AntiKt, R = 1.0, [p = -1,] [recombine = +,] [strategy = RecoStrategy.Best])
+cs = jet_reconstruct(particles::AbstractVector{T}; algorithm = JetAlgorithm.AntiKt, R = 1.0, [p = -1,] [recombine = +,] [strategy = RecoStrategy.Best])
 ```
 
 - `particles` - a one dimensional array (vector) of input particles for the clustering


### PR DESCRIPTION
 The signatures in readme still mention `Vector{T}` instead of `AbstractVector{T}`
This is follow up to #150 - we forgot to update readme :grin: 