### PR TITLE
Fix for jet constituent indexes

### DIFF
--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -617,7 +617,7 @@ given jet.
 An vector of indices representing the original constituents of the given jet.
 """
 function constituent_indexes(jet::T, cs::ClusterSequence{T}) where {T <: FourMomentum}
-    get_all_ancestors(cs.history[jet._cluster_hist_index].jetp_index, cs)
+    get_all_ancestors(jet._cluster_hist_index, cs)
 end
 
 """

--- a/test/test-constituents.jl
+++ b/test/test-constituents.jl
@@ -9,7 +9,7 @@ function Base.isapprox(j1::PseudoJet, j2::PseudoJet)
 end
 
 # Expected constituent indexes and parent indexes
-const expected_constituent_indexes = [84, 85, 139, 86, 133, 74, 79, 124, 76, 75, 163]
+const expected_constituent_indexes = [167, 87, 119, 168, 151, 152, 49, 143, 41, 106]
 const expected_parent_indexes = [320, 335]
 
 input_file = joinpath(dirname(pathof(JetReconstruction)), "..", "test", "data",
@@ -27,7 +27,7 @@ pj_jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet)
 @testset "Jet constituents" begin
     @testset "Constituents of jet number $(event_no)" begin
         my_constituents = JetReconstruction.constituents(pj_jets[event_no], cluster_seq)
-        @test size(my_constituents)[1] == 11
+        @test size(my_constituents)[1] == length(expected_constituent_indexes)
         for (i, idx) in enumerate(expected_constituent_indexes)
             @test my_constituents[i] ≈ events[1][idx]
         end
@@ -35,7 +35,7 @@ pj_jets = inclusive_jets(cluster_seq; ptmin = 5.0, T = PseudoJet)
 
     @testset "Constituent indexes for jet number $(event_no)" begin
         my_constituent_indexes = constituent_indexes(pj_jets[event_no], cluster_seq)
-        @test size(my_constituent_indexes)[1] == 11
+        @test size(my_constituent_indexes)[1] == length(expected_constituent_indexes)
         # Testing the index values is sufficient, the content came from the original input file!
         @test my_constituent_indexes == expected_constituent_indexes
     end


### PR DESCRIPTION
The index used to retrieve ancestors of a jet was wrong, as reported in #183. 

This is a fix for the 0.4 branch (#184 contains the fix for `main`).