### PR TITLE
Update Makie compat to allow building docs with Julia 1.12

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,4 +12,4 @@ JetReconstruction = {path = ".."}
 [compat]
 Documenter = "1.4"
 EDM4hep = "0.4"
-Makie = "0.20, 0.21"
+Makie = "0.20, 0.21, 0.22, 0.23, 0.24"


### PR DESCRIPTION
The version of Makie used in docs has to be update so the documentation can be build with Julia 1.12.0