### PR TITLE
Add cluster_hist_index argument for EDM4hep reconstructed particles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,9 +48,10 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
+EDM4hep = "eb32b910-dde9-4347-8fce-cd6be3498f0c"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ArgParse", "Test", "JSON", "Random"]
+test = ["Aqua", "ArgParse", "Test", "JSON", "Random", "EDM4hep"]

--- a/ext/EDM4hepJets.jl
+++ b/ext/EDM4hepJets.jl
@@ -38,9 +38,11 @@ JetReconstruction.energy(recoparticle::ReconstructedParticle) = recoparticle.ene
 
 Construct an EEJet from a ReconstructedParticle.
 """
-function JetReconstruction.EEJet(recoparticle::ReconstructedParticle)
+function JetReconstruction.EEJet(recoparticle::ReconstructedParticle;
+                                 cluster_hist_index::Int = 0)
     EEJet(JetReconstruction.px(recoparticle), JetReconstruction.py(recoparticle),
-          JetReconstruction.pz(recoparticle), JetReconstruction.energy(recoparticle))
+          JetReconstruction.pz(recoparticle), JetReconstruction.energy(recoparticle);
+          cluster_hist_index)
 end
 
 """
@@ -48,9 +50,11 @@ end
 
 Construct an PseudoJet from a ReconstructedParticle.
 """
-function JetReconstruction.PseudoJet(recoparticle::ReconstructedParticle)
+function JetReconstruction.PseudoJet(recoparticle::ReconstructedParticle;
+                                     cluster_hist_index::Int = 0)
     PseudoJet(JetReconstruction.px(recoparticle), JetReconstruction.py(recoparticle),
-              JetReconstruction.pz(recoparticle), JetReconstruction.energy(recoparticle))
+              JetReconstruction.pz(recoparticle), JetReconstruction.energy(recoparticle);
+              cluster_hist_index)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ function main()
     # Basic tests for the Jet types
     include("test-jet-types.jl")
     include("test-jet-constructors.jl")
+    include("test-edm4hep.jl")
 
     # Jet utilities tests
     include("test-jet-utils.jl")

--- a/test/test-edm4hep.jl
+++ b/test/test-edm4hep.jl
@@ -1,0 +1,26 @@
+# Test that we can work with EDM4hep particles
+
+include("common.jl")
+
+using EDM4hep
+
+dummyRecoParticle = ReconstructedParticle(energy = 4.0f0,
+                                          momentum = Vector3f(1.0f0, 2.0f0, 3.0f0))
+
+@testset "Construction of jets from EDM4hep particles" begin
+    eej = EEJet(dummyRecoParticle)
+    pj = PseudoJet(dummyRecoParticle)
+    @test typeof(EEJet(dummyRecoParticle)) === EEJet
+    @test typeof(EEJet(dummyRecoParticle; cluster_hist_index = 99)) === EEJet
+    @test JetReconstruction.energy(eej) == dummyRecoParticle.energy
+    @test JetReconstruction.px(eej) == dummyRecoParticle.momentum.x
+    @test JetReconstruction.py(eej) == dummyRecoParticle.momentum.y
+    @test JetReconstruction.pz(eej) == dummyRecoParticle.momentum.z
+
+    @test typeof(PseudoJet(dummyRecoParticle)) === PseudoJet
+    @test typeof(PseudoJet(dummyRecoParticle; cluster_hist_index = 99)) === PseudoJet
+    @test JetReconstruction.energy(pj) == dummyRecoParticle.energy
+    @test JetReconstruction.px(pj) == dummyRecoParticle.momentum.x
+    @test JetReconstruction.py(pj) == dummyRecoParticle.momentum.y
+    @test JetReconstruction.pz(pj) == dummyRecoParticle.momentum.z
+end


### PR DESCRIPTION
It is necessary for construction of EEJets from `::ReconstructedParticle` that the `cluster_hist_index` is an optional argument so that the calls from the jet preprocessor (setting the correct `cluster_hist_index`) work.

This has been checked against the examples in `examples/EDM4hep`, both of which now work.

A basic test case has been introduced that tests that EEJet and PseudoJet can be constructed from an `EDM4hep.edm4hep!ReconstructedParticle`. This requires adding EDM4hep to the `test` environment.

Closes #228 
Closes #230 