### PR TITLE
Improved statistics for benchmarks

### DIFF
--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -4,8 +4,11 @@ FlameGraphs = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JetReconstruction = "44e8cb2c-dfab-4825-9c70-d4808a591196"
 LorentzVectorHEP = "f612022c-142a-473f-8cfd-a09cf3793c6c"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 StatProfilerHTML = "a8a75453-ed82-57c9-9e16-4cd1196ecbf5"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [sources]
 JetReconstruction = {path = ".."}

--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -10,9 +10,13 @@ using FlameGraphs: FlameGraphs
 
 using ArgParse
 using Profile
+using Printf
 using StatProfilerHTML
+using Statistics
+using StatsBase
 using Logging
 using JSON
+using UnicodePlots
 
 using LorentzVectorHEP
 using JetReconstruction
@@ -126,15 +130,15 @@ function benchmark_jet_reco(events::Vector{Vector{T}};
         jet_collection = FinalJets[]
     end
 
+    # Vector for the trial results
+    trial_timing = zeros(Float64, nsamples)
+
     # Set consistent algorithm power
     p = JetReconstruction.get_algorithm_power(p = p, algorithm = algorithm)
     @info "Jet reconstruction will use $(algorithm) with power $(p)"
 
     # Now setup timers and run the loop
     GC.gc()
-    cumulative_time = 0.0
-    cumulative_time2 = 0.0
-    lowest_time = typemax(Float64)
     # Do a warm up run if we are running more than once
     start = nsamples > 1 ? 0 : 1
     for irun in start:nsamples
@@ -178,41 +182,75 @@ function benchmark_jet_reco(events::Vector{Vector{T}};
         gcoff && GC.enable(true)
         if irun > 0
             dt_μs = convert(Float64, t_stop - t_start) * 1.e-3
-            if nsamples > 1
-                @info "$(irun)/$(nsamples) $(dt_μs)"
-            end
-            cumulative_time += dt_μs
-            cumulative_time2 += dt_μs^2
-            lowest_time = dt_μs < lowest_time ? dt_μs : lowest_time
+            trial_timing[irun] = dt_μs / length(events)
         end
     end
-
-    mean = cumulative_time / nsamples
-    cumulative_time2 /= nsamples
-    if nsamples > 1
-        sigma = sqrt(nsamples / (nsamples - 1) * (cumulative_time2 - mean^2))
-    else
-        sigma = 0.0
-    end
-    mean /= length(events)
-    sigma /= length(events)
-    lowest_time /= length(events)
-    # Why also record the lowest time? 
-    # 
-    # The argument is that on a "busy" machine, the run time of an application is
-    # always TrueRunTime+Overheads, where Overheads is a nuisance parameter that
-    # adds jitter, depending on the other things the machine is doing. Therefore
-    # the minimum value is (a) more stable and (b) reflects better the intrinsic
-    # code performance.
-    println("Processed $(length(events)) events $(nsamples) times")
-    println("Average time per event $(mean) ± $(sigma) μs")
-    println("Lowest time per event $lowest_time μs")
 
     if !isnothing(dump)
         open(dump, "w") do io
             JSON.print(io, jet_collection, 2)
         end
     end
+    trial_timing
+end
+
+"""
+    function print_statistics(trial_stats; outlier_exclusion = true, 
+        outlier_band = 2, plot = false)
+
+Give a statistical summary of trial runs. Statistics for the whole
+sample are given, as well as those with outliers removed.
+
+# Notes
+
+## Why also record the lowest time? 
+ 
+The argument is that on a "busy" machine, the run time of an application is
+always TrueRunTime+Overheads, where Overheads is a nuisance parameter that
+adds jitter, depending on the other things the machine is doing. Therefore
+the minimum value is (a) more stable and (b) reflects better the intrinsic
+code performance.
+"""
+function print_statistics(trial_stats; outlier_exclusion = true, outlier_band = 2.0,
+                          plot = false)
+    sstats = summarystats(trial_stats)
+    iqr = sstats.q75 - sstats.q25
+    println("Full statistics ($(sstats.nobs) samples)")
+    println(pprint_trial_stats(sstats))
+
+    if outlier_exclusion
+        # The interquartile range (Q3 - Q1, or q75% - q25%) is the most useful way to filter outliers
+        # as it's insensitive to the outliers themselves (unlike σ)
+        min_val = sstats.q25 - outlier_band * iqr
+        max_val = sstats.q75 + outlier_band * iqr
+        no_outliers = trial_stats[(a -> a >= min_val && a <= max_val).(trial_stats)]
+        no_outliers_stats = summarystats(no_outliers)
+        println("Excluding outliers at $(outlier_band)xIQR (leaving $(no_outliers_stats.nobs) of $(sstats.nobs) samples)")
+        println(pprint_trial_stats(no_outliers_stats))
+    end
+
+    if plot
+        # Derive bin width from the IQR and number of samples
+        bin_width = ceil(2iqr / sstats.nobs^(1 / 3))
+        # No more than 80 bins (sometimes this gets way too big if there's an extreme outlier)
+        hbins = min(ceil((sstats.max - sstats.min) / bin_width), 80)
+
+        println(histogram(trial_stats, nbins = hbins, vertical = true,
+                          title = "Histogram of event time per trial"))
+        println(lineplot(collect(1:length(trial_stats)), trial_stats,
+                         title = "Runtime per event across trials"))
+    end
+end
+
+"""
+    function pprint_trial_stats(sstats)
+
+Generate a "pretty printed" string from a StatsBase statistics object,
+which is basically use @sprintf to limit the precision
+"""
+function pprint_trial_stats(sstats)
+    " - average time per event " * @sprintf("%.2f", sstats.mean) * " ± " * @sprintf("%.2f", sstats.sd) * " μs\n" *
+    " - lowest time per event " * @sprintf("%.2f", sstats.min) * " μs"
 end
 
 function parse_command_line(args)
@@ -290,6 +328,10 @@ function parse_command_line(args)
         help = "Provide memory allocation statistics."
         action = :store_true
 
+        "--plot"
+        help = "Plot a histogram of trail times on the terminal"
+        action = :store_true
+
         "--dump"
         help = "Write list of reconstructed jets to a JSON formatted file"
 
@@ -334,7 +376,8 @@ function main()
                                                                   maxevents = args[:maxevents],
                                                                   skipevents = args[:skip])
 
-    # Major switch between modes of running 
+    # Major switch between modes of running
+    trial_stats = nothing
     if args[:alloc]
         allocation_stats(events; distance = args[:distance],
                          p = args[:power], γ = args[:gamma], algorithm = args[:algorithm],
@@ -347,14 +390,19 @@ function main()
                      algorithm = args[:algorithm], strategy = args[:strategy],
                      recombine = JetReconstruction.RecombinationMethods[args[:recombine]])
     else
-        benchmark_jet_reco(events, distance = args[:distance], algorithm = args[:algorithm],
-                           p = args[:power], γ = args[:gamma],
-                           strategy = args[:strategy],
-                           recombine = JetReconstruction.RecombinationMethods[args[:recombine]],
-                           ptmin = args[:ptmin], dcut = args[:exclusive_dcut],
-                           njets = args[:exclusive_njets],
-                           nsamples = args[:nsamples], gcoff = args[:gcoff],
-                           dump = args[:dump], dump_cs = args[:dump_clusterseq])
+        trial_stats = benchmark_jet_reco(events, distance = args[:distance],
+                                         algorithm = args[:algorithm],
+                                         p = args[:power], γ = args[:gamma],
+                                         strategy = args[:strategy],
+                                         recombine = JetReconstruction.RecombinationMethods[args[:recombine]],
+                                         ptmin = args[:ptmin], dcut = args[:exclusive_dcut],
+                                         njets = args[:exclusive_njets],
+                                         nsamples = args[:nsamples], gcoff = args[:gcoff],
+                                         dump = args[:dump],
+                                         dump_cs = args[:dump_clusterseq])
+    end
+    if !isnothing(trial_stats)
+        print_statistics(trial_stats; plot = args[:plot])
     end
     nothing
 end

--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -249,7 +249,8 @@ Generate a "pretty printed" string from a StatsBase statistics object,
 which is basically use @sprintf to limit the precision
 """
 function pprint_trial_stats(sstats)
-    " - average time per event " * @sprintf("%.2f", sstats.mean) * " ± " * @sprintf("%.2f", sstats.sd) * " μs\n" *
+    " - average time per event " * @sprintf("%.2f", sstats.mean) * " ± " *
+    @sprintf("%.2f", sstats.sd) * " μs\n" *
     " - lowest time per event " * @sprintf("%.2f", sstats.min) * " μs"
 end
 

--- a/examples/instrumented-jetreco.jl
+++ b/examples/instrumented-jetreco.jl
@@ -251,6 +251,7 @@ which is basically use @sprintf to limit the precision
 function pprint_trial_stats(sstats)
     " - average time per event " * @sprintf("%.2f", sstats.mean) * " ± " *
     @sprintf("%.2f", sstats.sd) * " μs\n" *
+    " - median time per event " * @sprintf("%.2f", sstats.median) * " μs\n" *
     " - lowest time per event " * @sprintf("%.2f", sstats.min) * " μs"
 end
 


### PR DESCRIPTION
For benchmarking jet reconstruction improve the code organisation and the statistical analysis of trial runs.

The analysis of statistics is now moved to a separate function (out of the actual benchmarking function), uses Julia Statistics/StatsBase and prints in a more sensible way (2 decimal places).

An outlier removal pass is run, which filters out values that are well outside the main range of values (e.g., if the garbage collector ran, which causes a very high runtime spike). This is based on the interquartile range, which is insensitive to the presence of a few outliers (unlike the standard deviation).

There is also now a "--plot" option that will print out a unicode plot of the histogram of trial runs and a bar plot showing time per event vs. trial number, which helps to understand the results.

This is what the output now looks like, including a plot:

```sh
 ~/code/dev/JetReconstruction/examples/ [type-generalisation] julia --project instrumented-jetreco.jl --algorithm=AntiKt -R 0.4 ../test/data/events.pp13TeV.hepmc3.zst -S N2Tiled -m 512 --plot --gcoff
Full statistics (512 samples)
 - average time per event 136.93 ± 7.76 μs
 - lowest time per event 127.51 μs
Excluding outliers at 2.0xIQR (leaving 483 of 512 samples)
 - average time per event 135.79 ± 3.45 μs
 - lowest time per event 127.51 μs
       ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀Histogram of event time per trial⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ 
       ┌                                                                     ┐ 
   143  ⠀⠀⠀⠀█⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀⠀█⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀▁█⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀██⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀██⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀██⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀███⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀███⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀███⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀███⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀⠀███▇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀▇████⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀█████⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
        ⠀⠀█████▄▇▅▃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀  
     0  ▁▃█████████▆▄▂▂⠀⠀⠀▁⠀⠀⠀⠀▁⠀⠀⠀⠀⠀▁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀▁  
       └                                                                     ┘ 
       ⠀126⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀264⠀ 
       ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀μ ± σ: 136.93 ± 7.76⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ 
       ⠀⠀⠀⠀⠀⠀Runtime per event across trials⠀⠀⠀⠀⠀ 
       ┌────────────────────────────────────────┐ 
   300 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡄⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠀⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⠀⠀⠀⣆⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⢀⠀⠀⠀⠀⠀⠀│ 
       │⢰⠀⠀⠀⠀⠀⠀⣦⠀⠀⠀⡆⠀⠀⠀⠀⡀⢸⠀⢠⢠⣿⣿⣷⣇⢀⠀⣶⣴⣴⣤⣇⣧⣿⡆⠀⠀⠀⠀⠀│ 
       │⡿⠾⠶⠞⠷⠷⠞⠿⠾⠶⠖⠻⠷⠿⠛⠿⠛⠿⠟⢿⠻⠿⠋⠻⢹⠛⠿⠿⠿⠛⠿⠟⠉⠁⠀⠀⠀⠀⠀⠀│ 
       │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
   100 │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
       └────────────────────────────────────────┘ 
       ⠀0⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀600⠀ 
```