### PR TITLE
make jet index mismatch error message more descriptive

### DIFF
--- a/src/ClusterSequence.jl
+++ b/src/ClusterSequence.jl
@@ -92,7 +92,7 @@ function initial_history(particles)
 
         # get cross-referencing right from the Jets
         # particles[i]._cluster_hist_index = i
-        @assert cluster_hist_index(particles[i])==i "Cluster history index should match jet's index in the input vector"
+        @assert cluster_hist_index(particles[i])==i "Cluster history index should match jet's index in the input vector. Expected $(i), got $(cluster_hist_index(particles[i]))"
 
         # determine the total energy in the event
         Qtot += particles[i].E


### PR DESCRIPTION
One too many times I got this error and was wondering what went wrong.
Adding information about expected and actual values of indices in the error message