### PR TITLE
Fix spurious changes to examples Project.toml

### DIFF
--- a/test/test-basic-examples.jl
+++ b/test/test-basic-examples.jl
@@ -4,13 +4,13 @@ include("common.jl")
 
 const JULIA_CMD = Base.julia_cmd()
 const EXAMPLES_PROJECT = joinpath(@__DIR__, "..", "examples")
-const PACKAGE_ROOT = joinpath(@__DIR__, "..")
 
 @testset "Instantiate examples environment" begin
     instantiate_examples = """
         using Pkg
+        cd($(repr(EXAMPLES_PROJECT)))
         Pkg.activate($(repr(EXAMPLES_PROJECT)))
-        Pkg.develop(Pkg.PackageSpec(path=$(repr(PACKAGE_ROOT))))
+        Pkg.develop(path="..")
         Pkg.instantiate()
     """
     @test success(run(`$JULIA_CMD -e $instantiate_examples`))


### PR DESCRIPTION
The PR in #244 fixed the setup of the `examples` environment for testing, but had the unfortunate side effect of writing the dev path to JetReconstruction as an *absolute* path, which is both a spurious change and a broken one for any other machine.

This PR fixes that so that the "develop" path for JetReconstruction in examples is always a relative one, viz. `".."`.
